### PR TITLE
Utilize dockerfile to build php:apache to prevent extra commands during running containers

### DIFF
--- a/Dockerfile.apache
+++ b/Dockerfile.apache
@@ -1,0 +1,5 @@
+# Use an official PHP Apache image as the base image
+FROM php:8.3-apache
+
+# Install mysqli extension
+RUN docker-php-ext-install mysqli && a2enmod rewrite

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ A one-page map, powered by Leafletjs, is utilized to present a heatmap of the ro
 The Snowdog Geospatial Data Collection System stands as a comprehensive solution for users seeking to collect and visualize geospatial data using geofences. This system seamlessly integrates cutting-edge technologies, providing a reliable and user-friendly experience for mountainbikers for observing winter trail condition.
 
 # Running the service
-Just point and click either the fire_up_dev_env.bat or the linux equivalent and go to address http://localhost/snowdog/
+1. make all
+2. docker-compose up -d --build
+3. go to address http://localhost/snowdog/
 
 ![Screenshot](snowdog.png)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
       - mynetwork
 
   apache:
-    image: php:8.3-apache
     container_name: apache-container
+    build:
+      context: .
+      dockerfile: Dockerfile.apache
     volumes:
       - ./web_app:/var/www/html/snowdog
     environment:
@@ -62,6 +64,7 @@ services:
       dockerfile: Dockerfile.snowdog_simulator
     depends_on:
       - mqtt-broker
+      - apache
     networks:
       - mynetwork
 # volumes for mapping data,config and log

--- a/fire_up_dev_env.bat
+++ b/fire_up_dev_env.bat
@@ -1,8 +1,0 @@
-@echo off
-docker-compose.exe up -d
-docker.exe exec -it apache-container bash -c "docker-php-ext-install mysqli && apachectl restart"
-docker.exe cp .\testdata.sql mysql-container:/tmp
-echo "Waiting for mysql to start..."
-timeout /t 5 /nobreak >nul
-docker.exe exec -it mysql-container bash -c "mysql -u root --password=root < /tmp/testdata.sql"
-bash -c "./apitest.sh"

--- a/fire_up_dev_env.sh
+++ b/fire_up_dev_env.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-docker-compose up -d
-docker exec -it apache-container bash -c 'docker-php-ext-install mysqli && apachectl restart'
-docker cp testdata.sql mysql-container:/tmp
-sleep 5
-docker exec -it mysql-container bash -c 'mysql -u root --password=root -h localhost < /tmp/testdata.sql'
-./apitest.sh

--- a/mysql_api_test.sh
+++ b/mysql_api_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# this can be run when docker containers are up and running
+
+docker cp testdata.sql mysql-container:/tmp
+sleep 5
+docker exec -it mysql-container bash -c 'mysql -u root --password=root -h localhost < /tmp/testdata.sql'
+./apitest.sh


### PR DESCRIPTION
closes #18, closes #19